### PR TITLE
Fix notice: WritingHelper::$supported_post_types

### DIFF
--- a/writing-helper.php
+++ b/writing-helper.php
@@ -50,8 +50,6 @@ class WritingHelper {
 
 	public function action_init() {
 
-		$this->supported_post_types = apply_filters( 'wh_supported_post_types', $this->supported_post_types );
-
 		// Helpers each have an init() method
 		foreach( $this->helpers as $helper ) {
 			if ( method_exists( $helper, 'init' ) )


### PR DESCRIPTION
```
[09-Dec-2013 18:15:35 UTC] PHP Notice:  Undefined property: WritingHelper::$supported_post_types in /srv/www/vocativ.dev/content/plugins/writing-helper/writing-helper.php on line 53
```

Variable was removed in 6596d9ca0e7a3f8a158849d701e3b1211a3626fe
