### PR TITLE
Define MB_IN_BYTES if it's not defined

### DIFF
--- a/writing-helper.php
+++ b/writing-helper.php
@@ -11,6 +11,9 @@ Text Domain: writing-helper
 
 define( 'WH_VERSION', '1.0-rc1' );
 
+if ( ! defined( 'MB_IN_BYTES' ) )
+	define( 'MB_IN_BYTES', 1024 * 1024 );
+
 foreach( glob( dirname(__FILE__). '/class-*.php' ) as $wh_php_file_name ) {
 	require $wh_php_file_name;
 }


### PR DESCRIPTION
There is a core patch on https://core.trac.wordpress.org/ticket/22405 that would also fix this, but until that's merged, we need to explicitly define `MB_IN_BYTES`.

Fixes #15