### PR TITLE
Fix undefined constant MB_IN_BYTES

### DIFF
--- a/templates/partials/feedback-form-copy.tpl.php
+++ b/templates/partials/feedback-form-copy.tpl.php
@@ -67,7 +67,7 @@
 								id="cp-<?php the_ID() ?>" />
 						&nbsp;
 						<span class="title"><?php the_title() ?></span>
-						<?php if ( strlen( $post->post_content ) > MB_IN_BYTES / 5 ) : ?>
+						<?php if ( strlen( $post->post_content ) > pow( 1024, 2 ) / 5 ) : ?>
 							<span class="excerpt">
 								<?php esc_html_e( 'Excerpt cannot be retrieved.', 'writing-helper' ); ?>
 							</span>
@@ -99,7 +99,7 @@
 								id="cp-<?php the_ID() ?>" />
 						&nbsp;
 						<span class="title"><?php the_title() ?></span>
-						<?php if ( strlen( $post->post_content ) > MB_IN_BYTES / 5 ) : ?>
+						<?php if ( strlen( $post->post_content ) > pow( 1024, 2 ) / 5 ) : ?>
 							<span class="excerpt">
 								<?php esc_html_e( 'Excerpt cannot be retrieved.', 'writing-helper' ); ?>
 							</span>


### PR DESCRIPTION
We're noticing a PHP Notice being raised in the writing-helper plugin, per Query Monitor in VIP Quickstart:

> Notice: Use of undefined constant MB_IN_BYTES - assumed 'MB_IN_BYTES'	
/srv/www/wp-content/plugins/writing-helper/templates/partials/feedback-form-copy.tpl.php:102
Writing_Helper->meta_box_content()

Fixes https://github.com/Automattic/writing-helper/issues/15