### PR TITLE
Add feedback request email header filter.

### DIFF
--- a/class-draft-feedback.php
+++ b/class-draft-feedback.php
@@ -76,7 +76,16 @@ class Writing_Helper_Draft_Feedback {
 	private function email_headers( &$user ) {
 		$headers = 'Reply-To: ' . $user->display_name . ' <' . $user->user_email . ">\r\n";
 		$headers .= "From: " . $user->display_name . " <donotreply@wordpress.com>\r\n";
-		return $headers;
+
+		/**
+		 * Filter the headers included in the outgoing feedback request email.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string  $headers The "from" and "reply-to" headers.
+		 * @param WP_User $user    WP_User object of user requesting feedback.
+		 */
+		return apply_filters( 'writing_helper_feedback_email_headers', $headers, $user );
 	}
 
 	private function email_post_published( $email, $post, $request ) {


### PR DESCRIPTION
Allow end users to filter the “from” and “reply-to” values.
# 

I mostly wanted to submit this PR so I could say how excellent this plugin will be as a Share-A-Draft replacement/update. I saw this functionality when asked for feedback on https://bpdevel.wordpress.com and had been looking to replace Share-A-Draft. I'm really impressed with the great work that's gone into this feature--it's a simpler and more powerful tool for both the feedback-requester and feedback-giver to use. Thanks!
