### PR TITLE
Prevent shareadraft filters from clobbering all queries

### DIFF
--- a/class-draft-feedback.php
+++ b/class-draft-feedback.php
@@ -312,6 +312,8 @@ Regards,
 	 * If you shared this post it stores the post locally.
 	 */
 	function posts_results_intercept( $posts ) {
+		remove_filter( 'posts_results', array( $this, 'posts_results_intercept' ) );
+
 		if (1 != count( $posts ) ) return $posts;
 		$post = &$posts[0];
 		/* Don't use get_post_status(), because it generates a DB query,
@@ -336,6 +338,8 @@ Regards,
 	 * If the post was stored locally, it returns it for rendering.
 	 */
 	function the_posts_intercept( $posts ) {
+		remove_filter( 'the_posts', array( $this, 'the_posts_intercept' ) );
+        
 		if ( !empty( $posts ) && ( isset( $_GET['nux'] ) && $_GET['nux'] == 'nuts' ) ) {
 			// site admins always have a post
 			$overwrite_post = true;


### PR DESCRIPTION
Fixes #21 

I initially tried using some variants of trying to do some kind of conditionals on what query the current query is, like `global $wp_query; if ( $wp_query->is_main_query ) ...`. The problem is that since these aren't query filters, they don't get the query object passed in, so that's not quite so simple to do.

I ended up just `remove_filter`ing after the first time the filter is processed, because presumably this will apply to the main $wp request, which will be the first query to be processed on a page. A possible enhancement would be do a conditional check around the current query in a `pre_get_posts` action, and attach these functions to `the_posts` and `posts_results` from there, rather than always attaching them on `init`. That way we could filter the result of the main query, whether or not its the first query run.

Thoughts?
