### PR TITLE
:hammer: Fix PHP fatal error on upgrading to PHP 8.0

### DIFF
--- a/class-copy-post.php
+++ b/class-copy-post.php
@@ -63,7 +63,7 @@ class Writer_Helper_Copy_Post {
 		Writing_Helper::json_return( self::get_candidate_posts( $post_type, $search_terms ) );
 	}
 
-	function get_candidate_posts( $post_type = 'post', $search_terms = '', $sticky = false ) {
+	public static function get_candidate_posts( $post_type = 'post', $search_terms = '', $sticky = false ) {
 		$sticky_posts = get_option( 'copy_a_post_sticky_posts' );
 		$post_parameters = array(
 			'post_type' => $post_type,


### PR DESCRIPTION
**Issue**

- After upgrading to PHP 8.0, the `writing-helper` plugin throws a fatal error on the site.
- Here is the snapshot of debug log provided by WordPress.

<img width="1440" alt="Screenshot 2022-05-25 at 3 56 20 PM" src="https://user-images.githubusercontent.com/58802366/170241590-dad1b9f5-6190-400a-b8b2-cdaa3f3fb24b.png">

**Observation**

- The fatal error is due to the method `candidate_posts` of class `Writer_Helper_Copy_Post` is called statically, but the function is not defined as static. In the previous version of PHP, it would work. But due to large error handling in PHP 8.0,  This serves as the fatal error and breaks the site.

**Solution**

- A quick solution for the site serving on `VIP` with the `writing-helper` plugin enabled and wanted to move on `PHP 8.0` is to change the function `candidate_posts` to `static` function.

```
public static function get_candidate_posts( $post_type = 'post', $search_terms = '', $sticky = false ) {
```

**Conclusion**

- After the fix added the site is Working UP and Fine, No more fatal error is being shown in debug log.
- Closes the issue #32 